### PR TITLE
Fix a typo in `tests/mocha.css`

### DIFF
--- a/tests/mocha.css
+++ b/tests/mocha.css
@@ -224,4 +224,4 @@ code .comment { color: #ddd }
 code .init { color: #2F6FAD }
 code .string { color: #5890AD }
 code .keyword { color: #8A6343 }
-code .number { color: #2F6FAD }<g
+code .number { color: #2F6FAD }


### PR DESCRIPTION
Commit c2fe32d introduced a syntax error in `tests/mocha.css`.
