### PR TITLE
loosen jquery dependency

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,6 +3,6 @@
     "version": "1.2.1",
     "main": "./dist/garlic.min.js",
     "dependencies": {
-        "jquery": "1.8.*"
+        "jquery": "*"
     }
 }


### PR DESCRIPTION
don't think there's any reason the dep needs be to be jQuery `1.8.*`, right?