### PR TITLE
Set { defined: false } when localStorage.setItem throws errors

### DIFF
--- a/garlic.js
+++ b/garlic.js
@@ -16,6 +16,15 @@
    * =============================== */
   var Storage = function ( options ) {
     this.defined = 'undefined' !== typeof localStorage;
+
+    // https://github.com/Modernizr/Modernizr/blob/5eea7e2a213edc9e83a47b6414d0250468d83471/feature-detects/storage/localstorage.js#L40
+    var key = 'garlic:' + document.domain + '>test';
+    try {
+      localStorage.setItem(key, key);
+      localStorage.removeItem(key);
+    } catch (e) {
+      this.defined = false;
+    }
   };
 
   Storage.prototype = {


### PR DESCRIPTION
This is a way to suppress exception when in private mode for safari.
https://github.com/guillaumepotier/Garlic.js/issues/90

Approach has been copied from Modernizer repository : https://github.com/Modernizr/Modernizr/blob/5eea7e2a213edc9e83a47b6414d0250468d83471/feature-detects/storage/localstorage.js#L40
