### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#Changelog
+# Changelog
 
 * **1.2.4** :
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,4 +1,4 @@
-#Contribute!
+# Contribute!
 
 * fork repository
 * `npm install`

--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
-#Garlic.js
+# Garlic.js
 
 [![Build Status](https://secure.travis-ci.org/guillaumepotier/Garlic.js.png?branch=master)](https://travis-ci.org/guillaumepotier/Garlic.js)
 
 Garlic.js allows you to automatically persist your forms' text and select field values locally, until the form is submitted. This way, your users don't lose any precious data if they accidentally close their tab or browser.
 
-#Demonstration / Documentation
+# Demonstration / Documentation
 
 http://garlicjs.org/
 
-#Version
+# Version
 
 1.3.0
 
 See CHANGELOG for more info.
 
-#TODO
+# TODO
 
 * Improve doc and api;
 * Refactorize some code;
 * Work on inputs radio and textarea where there are conflicts;
 * And much more, for fun!
 
-#Run tests
+# Run tests
 
 * In your browser: go to `tests/index.html`
 * Headless tests: `npm install && npm test`
 
-#Make production minified versions
+# Make production minified versions
 
 You'll need ruby, and Google Closure compiler: `gem install closure-compiler`. Then, just call:
 
@@ -34,7 +34,7 @@ You'll need ruby, and Google Closure compiler: `gem install closure-compiler`. T
 
 They'll be created and dumped in the dist/ directory
 
-#Contributors
+# Contributors
 
 * @cdmoyer
 * @johnrees
@@ -43,11 +43,11 @@ They'll be created and dumped in the dist/ directory
 * @willdurand
 * @nashby
 
-#Used / Inspiration
+# Used / Inspiration
 
 * localStorageshim for IE browsers: https://github.com/mattpowell/localstorageshim by @mattpowell
 * minify ruby script https://gist.github.com/765432 by @benpickles
 
-#Licence
+# Licence
 
 MIT - See LICENCE.md


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
