### PR TITLE
Add `pre` events to override storing and restoring

### DIFF
--- a/garlic.js
+++ b/garlic.js
@@ -140,10 +140,15 @@
       if ( this.options.expires ) {
         this.storage.set( this.expiresFlag , ( new Date().getTime() + this.options.expires * 1000 ).toString() );
       }
+      
+      // Allow changing the value
+      var prePersistValue = this.options.prePersist(this.$element, this.val);
+      if (typeof prePersistValue != 'false') {
+          this.val = prePersistValue;
+      }
 
-      this.storage.set( this.path , this.getVal() );
-
-      this.options.onPersist(this.$element, this.getVal());
+      this.storage.set(this.path , this.val);
+      this.options.onPersist(this.$element, this.val);
     }
 
     , getVal: function () {
@@ -444,6 +449,7 @@
     }
    , getPath: function ( $item ) {}                                                                         // Set your own key-storing strategy per field
    , onRetrieve: function ( $item, storedVal ) {}                                                           // This function will be triggered each time Garlic find an retrieve a local stored data for a field
+   , prePersist: function ( $item, storedVal ) { return false; }                                            // This function will be triggered before Garlic, and allows to override the value stored to local storage
    , onPersist: function ( $item, storedVal ) {}                                                            // This function will be triggered each time Garlic stores a field to local storage
    , onSwap: function ( $item, prevValue, curValue ) {}                                                     // This function will be triggered each time Garlic swap values with conflict manager
   }

--- a/garlic.js
+++ b/garlic.js
@@ -141,9 +141,9 @@
         this.storage.set( this.expiresFlag , ( new Date().getTime() + this.options.expires * 1000 ).toString() );
       }
       
-      // Allow changing the value
+      // Allow changing the value to any other string
       var prePersistValue = this.options.prePersist(this.$element, this.val);
-      if (typeof prePersistValue != 'false') {
+      if (typeof prePersistValue == 'string') {
           this.val = prePersistValue;
       }
 

--- a/garlic.js
+++ b/garlic.js
@@ -169,8 +169,15 @@
             this.$element.attr( 'expires-in',  Math.floor( ( parseInt( this.storage.get( this.expiresFlag ) ) - date ) / 1000 ) );
           }
         }
-
+        
+        var currentValue = this.$element.val();
         var storedValue = this.storage.get( this.path );
+
+        // Allow not restoring the value in case value was `false`
+        var storedValue = this.options.preRetrieve(this.$element, currentValue, storedValue);
+        if (typeof storedValue == 'boolean' && storedValue == false) {
+            return;
+        }
 
         // if conflictManager enabled, manage fields with already provided data, different from the one stored
         if ( this.options.conflictManager.enabled && this.detectConflict() ) {
@@ -448,6 +455,7 @@
       , onConflictDetected: function ( $item, storedVal ) { return true; }                                  // This function will be triggered if a conflict is detected on an item. Return true if you want Garlic behavior, return false if you want to override it
     }
    , getPath: function ( $item ) {}                                                                         // Set your own key-storing strategy per field
+   , preRetrieve: function ( $item, currentValue, storedVal ) { return storedVal; }                         // This function will be triggered before retrieve, and allows to override setting the field's value restored from local storage
    , onRetrieve: function ( $item, storedVal ) {}                                                           // This function will be triggered each time Garlic find an retrieve a local stored data for a field
    , prePersist: function ( $item, storedVal ) { return false; }                                            // This function will be triggered before Garlic, and allows to override the value stored to local storage
    , onPersist: function ( $item, storedVal ) {}                                                            // This function will be triggered each time Garlic stores a field to local storage

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -8,13 +8,26 @@ var testSuite = function () {
       e.preventDefault();
     } );
     $( '#form1' ).garlic( { domain: true } );
-    $( '#retrieve-trigger' ).garlic( { onRetrieve: function ( elem, retrieveVal ) {
-      elem.attr( 'storedValue', retrieveVal );
-    } } );
-    $( '#persist-trigger' ).garlic( { onPersist: function ( elem, persistVal ) {
-      console.log("Value: ", persistVal);
-      elem.attr( 'storedValue', persistVal );
-    } } );
+
+    $( '#retrieve-trigger' ).garlic( {
+        preRetrieve: function ( elem, retrieveVal, storedVal ) {
+          return 'preRetrieveValueChanged';
+        },
+        onRetrieve: function ( elem, retrieveVal ) {
+          elem.attr( 'storedValue', retrieveVal );
+        }
+    } );
+
+    $( '#persist-trigger' ).garlic( {
+      prePersist: function ( elem, persistVal ) {
+        return 'prePersistChanged';
+      },
+      onPersist: function ( elem, persistVal ) {
+        console.log("Value: ", persistVal);
+        elem.attr( 'storedValue', persistVal );
+      }
+    } );
+
     var garlicStorage = $( '#form1' ).garlic( 'getStorage' );
 
     $( '#custom-get-path-form' ).garlic( {
@@ -85,9 +98,9 @@ var testSuite = function () {
         garlicStorage.destroy( 'foo' );
         expect( garlicStorage.get( 'foo' ) ).to.be( null );
       } )
-      it ( 'If custom onPersist function is defined, execute it', function () {
+      it ( 'If custom prePersist and onPersist functions are defined, change value and do not return false', function () {
         $( '#persist-input' ).garlic ( 'persist', function () {
-          expect( $( '#persist-input' ).attr( 'storedValue' ) ).to.be( 'bar' );
+          expect( $( '#persist-input' ).attr( 'storedValue' ) ).to.be( 'prePersistChanged' );
         } );
       } )
     } )
@@ -215,7 +228,7 @@ var testSuite = function () {
       } )
       it ( 'If custom retrieval function is defined, execute it', function () {
         $( '#retrieve-input' ).garlic ( 'retrieve', function () {
-          expect( $( '#retrieve-input' ).attr( 'storedValue' ) ).to.be( 'foo' );
+          expect( $( '#retrieve-input' ).attr( 'storedValue' ) ).to.be( 'preRetrieveValueChanged' );
         } );
       } )
       it( 'When stored data is retrieved, an input event should be triggered', function ( done ) {


### PR DESCRIPTION
This allows us to add a `timestamp` to the data, so we can locally configure whether we want to use outdated values.

**Example**

```js
$('#garlicForm').garlic({
        # ...
        preRetrieve: function(elem, currentValue, restoredValue) {
            var cacheValue = JSON.parse(restoredValue);
            if (cacheValue.timestamp < getLastDateModified()) {
                return false;
            }
            return cacheValue.content;
        },
        prePersist: function(elem, storedValue) {
            var timestamp = getCurrentTimestamp();
            return parseCacheItem(timestamp, storedValue);
        }
    });
```

Fixes #93 