### PR TITLE
Trigger "change" event instead of "input"

### DIFF
--- a/garlic.js
+++ b/garlic.js
@@ -202,8 +202,8 @@
         // for input[type=text], select and textarea, just set val()
         this.$element.val( storedValue );
 
-        // trigger an input event given the value has been changed
-        this.$element.trigger( 'input' );
+        // trigger a change event given the value has been changed
+        this.$element.trigger( 'change' );
 
         // trigger custom user function when data is retrieved
         this.options.onRetrieve( this.$element, storedValue );


### PR DESCRIPTION
The `change` event seems more compatible with 3rd party libraries (see https://github.com/guillaumepotier/Garlic.js/issues/82).

WDYT ?