### PR TITLE
Moving webpack to a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "devDependencies": {
     "expect.js": "*",
     "mocha": "*",
-    "mocha-phantomjs": "*"
+    "mocha-phantomjs": "*",
+    "webpack": "^3.10.0"
   },
   "dependencies": {
-    "webpack": "^3.10.0"
   }
 }


### PR DESCRIPTION
Webpack shouldn't be a regular dependency since it's only used when developing the library (having it as a regular dependency messes up some tooling when including this lib via NPM/Yarn in other projects).