### PR TITLE
Menu on the left

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,8 @@
         }
 
         .bs-docs-sidenav.affix {
-            top: 200px;
+            top: 10px;
+            left: 10px;
         }
 
         #parsley {


### PR DESCRIPTION
On demo, the menu is over the content.
A quick fix to let user read the example.

Before:
![Menu on content](https://i.imgur.com/FZMYaVM.png)

After:
![Menu on the left](https://i.imgur.com/6LPKRdh.png)